### PR TITLE
fix: env-driven DB connection pool, drop CONN_MAX_AGE=600

### DIFF
--- a/config/helpers/env.py
+++ b/config/helpers/env.py
@@ -19,6 +19,10 @@ class EnvSettings(BaseSettings):
 
     # Database
     database_url: str
+    # Connection pool (per gunicorn worker; 3 workers x max_size = total per instance)
+    # Override DB_POOL_MAX_SIZE in prod env if a service hits real load.
+    db_pool_min_size: int = 0
+    db_pool_max_size: int = 5
 
     # Environment
     domain_name: str

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -58,10 +58,18 @@ DATABASES = {
     "default": {
         **dj_database_url.config(
             default=env.database_url,
-            conn_max_age=600,
             conn_health_checks=True,
         ),
         "ATOMIC_REQUESTS": True,
+        "OPTIONS": {
+            "pool": {
+                "min_size": env.db_pool_min_size,
+                "max_size": env.db_pool_max_size,
+                "timeout": 30,
+                "max_lifetime": 1800,
+                "max_idle": 120,
+            }
+        },
     },
 }
 


### PR DESCRIPTION
## Why

This template's `CONN_MAX_AGE=600` + `gunicorn --worker-class gevent` combo causes connection hoarding: every greenlet that touches the DB grabs its own connection and holds it for 10 minutes with **no upper bound**.

Six of my forks of this template (foodmatic, Dars, sukoon, almansk, Alfaheam-oud, homeservices) collectively hoarded **163/181 connections (90%) on the shared dev RDS instance** before I fixed them today. foodmatic alone held 62 idle connections from one App Runner instance.

Fixing it here in the template prevents future forks from inheriting the bug.

## What

### `config/helpers/env.py`
Add 2 typed Pydantic fields with sensible defaults:

```python
# Database
database_url: str
# Connection pool (per gunicorn worker; 3 workers x max_size = total per instance)
# Override DB_POOL_MAX_SIZE in prod env if a service hits real load.
db_pool_min_size: int = 0
db_pool_max_size: int = 5
```

### `config/settings/base.py`
Drop `conn_max_age=600`, add explicit psycopg3 pool with the env-driven sizes:

```diff
 DATABASES = {
     "default": {
         **dj_database_url.config(
             default=env.database_url,
-            conn_max_age=600,
             conn_health_checks=True,
         ),
         "ATOMIC_REQUESTS": True,
+        "OPTIONS": {
+            "pool": {
+                "min_size": env.db_pool_min_size,
+                "max_size": env.db_pool_max_size,
+                "timeout": 30,
+                "max_lifetime": 1800,
+                "max_idle": 120,
+            }
+        },
     },
 }
```

## Defaults

`min_size=0, max_size=5` × 3 gunicorn workers = **hard cap of 15 conns per App Runner instance**. Plenty for typical Django (~300 req/s capacity at ~50ms/req per conn). For high-traffic prod, override via env var:

```bash
DB_POOL_MAX_SIZE=15
```

Zero-config migration: existing forks that don't set the env var get the same behavior we just deployed everywhere.

## Why only 2 env vars (not 5)

- `min_size` / `max_size` = capacity tuning — **per-environment value**
- `timeout` / `max_lifetime` / `max_idle` = hygiene knobs — same everywhere, kept as constants

Avoids env-var sprawl while parameterizing what actually changes.

## Verified working

Same fix (with hard-coded 0/5) is running in production on:
- foodmatic-prod (deployed 2026-04-25 ~12:32 UTC, healthy, HTTP 302 on /admin/)
- foodmatic-dev (deployed same time, dev-shared connection count for foodmatic dropped 62 → 0)
- 5 other Eram-Group backends (Dars, sukoon, almansk, Alfaheam-oud, homeservices — deploys pending)

## Dependencies

Already satisfied — no `pyproject.toml` changes:
- `psycopg[pool]>=3.2` ✅
- `django>=5.1` ✅ (`OPTIONS.pool` requires Django ≥ 5.1)