### PR TITLE
chore: make DB_POOL_* required, document in dummy.env + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ This project uses GitHub Actions for CI/CD deployment to AWS. Follow these steps
      "DJANGO_ADMIN_URL": "admin/",
 
      "DATABASE_URL": "postgis://user:password@host:5432/dbname",
+     "DB_POOL_MIN_SIZE": "0",
+     "DB_POOL_MAX_SIZE": "5",
 
      "DOMAIN_NAME": "MUST-BE-REPLACED",
      "ENVIRONMENT": "development",

--- a/config/helpers/env.py
+++ b/config/helpers/env.py
@@ -20,9 +20,10 @@ class EnvSettings(BaseSettings):
     # Database
     database_url: str
     # Connection pool (per gunicorn worker; 3 workers x max_size = total per instance)
-    # Override DB_POOL_MAX_SIZE in prod env if a service hits real load.
-    db_pool_min_size: int = 0
-    db_pool_max_size: int = 5
+    # Required: must be set in dummy.env (local/CI) and AWS Secret Manager (prod).
+    # Defaults (0 / 5) live in dummy.env; override DB_POOL_MAX_SIZE in prod if needed.
+    db_pool_min_size: int
+    db_pool_max_size: int
 
     # Environment
     domain_name: str

--- a/dummy.env
+++ b/dummy.env
@@ -11,6 +11,9 @@ DISABLE_CSRF=False
 
 # Database
 DATABASE_URL=postgis://postgres:postgres@postgres:5432/mydatabase
+# Connection pool per gunicorn worker (3 workers x max_size = total per instance)
+DB_POOL_MIN_SIZE=0
+DB_POOL_MAX_SIZE=5
 
 # Environment
 DOMAIN_NAME=localhost


### PR DESCRIPTION
Followup to #201. Makes the DB pool fields required + documents them everywhere they're expected, so config drift fails loudly at startup instead of silently using a (possibly wrong) default.

## Changes

### `config/helpers/env.py` — remove defaults
```diff
-db_pool_min_size: int = 0
-db_pool_max_size: int = 5
+db_pool_min_size: int
+db_pool_max_size: int
```
Pydantic now raises `ValidationError` on app startup if either is missing — surfaces config drift immediately rather than silently falling back to defaults.

### `dummy.env` — add the vars (so local + CI work)
```diff
 # Database
 DATABASE_URL=postgis://postgres:postgres@postgres:5432/mydatabase
+# Connection pool per gunicorn worker (3 workers x max_size = total per instance)
+DB_POOL_MIN_SIZE=0
+DB_POOL_MAX_SIZE=5
```
Local dev (`cp dummy.env .env`) and CI (`docker compose -f docker-compose.local.yml`) both pick these up automatically.

### `README.md` — list in AWS Secret Manager config block
```diff
 "DATABASE_URL": "postgis://user:password@host:5432/dbname",
+"DB_POOL_MIN_SIZE": "0",
+"DB_POOL_MAX_SIZE": "5",
```
Anyone deploying a fresh instance from this template now sees these keys in the required-secrets list.

## Why this approach

The defaults-in-code pattern (from #201) is convenient but hides intent — a fork can `cp dummy.env .env` and never know these env vars exist. Making them required + documenting in dummy.env/README means:

- Devs see the values when they look at dummy.env
- New prod deploys can't silently miss them — Pydantic blocks startup
- Tuning per-environment is the obvious workflow, not a hidden trick

## Migration impact

Existing forks that pull this template change must add `DB_POOL_MIN_SIZE` and `DB_POOL_MAX_SIZE` to their AWS Secret Manager configs. The 6 already-patched Eram-Group backends (foodmatic, Dars, sukoon, almansk, Alfaheam-oud, homeservices) hard-code the values in their own `base.py`, so they're not affected by this template change.